### PR TITLE
NEW: Implement CUDA minor version compatibility

### DIFF
--- a/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.17cuda_compiler_version12.9.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0.yaml
+++ b/.ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.28'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.17cuda_compiler_version12.9.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0.yaml
+++ b/.ci_support/linux_aarch64_c_stdlib_version2.28cuda_compiler_version13.0.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.28'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
     - name: Build on Linux
       id: build-linux

--- a/README.md
+++ b/README.md
@@ -128,12 +128,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -160,7 +160,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/libmagma-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -159,7 +159,7 @@ outputs:
         - nomkl
       run:
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
-        - cuda-cudart
+        - cuda-cudart  # [(not win) or (cuda_compiler_version or "").startswith("12")]
         - libcublas
         - libcusparse
     test:
@@ -205,7 +205,7 @@ outputs:
       run:
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
         - {{ pin_subpackage('libmagma', exact=True) }}
-        - cuda-cudart
+        - cuda-cudart  # [(not win) or (cuda_compiler_version or "").startswith("12")]
         - libcusparse
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -95,7 +95,7 @@ source:
       - patches/0001-fix-compilation-issue-with-cuda-13.patch
 
 build:
-  number: 4
+  number: 5
   skip: true  # [cuda_compiler_version == "None"]
   # debugging skips below
   # skip: true  # [not (linux64 and cuda_compiler_version == "12.9")]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -138,6 +138,7 @@ outputs:
     build:
       ignore_run_exports:
         - cuda-version
+      # Ignore run exports to implement CUDA minor version compatibility
       ignore_run_exports_from:
         - cuda-cudart-dev
         - libcublas-dev
@@ -159,6 +160,8 @@ outputs:
         - nomkl
       run:
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
+        # Starting with CUDA 13.0 for Windows-only, cudart links are redirected to the
+        # CUDA driver at compile time. Therefore, cuda-cudart is not needed.
         - cuda-cudart  # [(not win) or (cuda_compiler_version or "").startswith("12")]
         - libcublas
         - libcusparse

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -135,6 +135,13 @@ outputs:
         - lib/pkgconfig  # [unix]
         - lib/libmagma_sparse.so  # [linux]
         - Library\bin\magma_sparse.dll  # [win]
+    build:
+      ignore_run_exports:
+        - cuda-version
+      ignore_run_exports_from:
+        - cuda-cudart-dev
+        - libcublas-dev
+        - libcusparse-dev
     requirements:
       build:
         - {{ compiler('c') }}
@@ -150,6 +157,11 @@ outputs:
         - liblapack
         - libblas
         - nomkl
+      run:
+        - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
+        - cuda-cudart
+        - libcublas
+        - libcusparse
     test:
       commands:
         - test -f $PREFIX/lib/libmagma${SHLIB_EXT}                 # [unix]
@@ -169,6 +181,12 @@ outputs:
       include:
         - lib/libmagma_sparse.so  # [linux]
         - Library\bin\magma_sparse.dll  # [win]
+    build:
+      ignore_run_exports:
+        - cuda-version
+      ignore_run_exports_from:
+        - cuda-cudart-dev
+        - libcusparse-dev
     requirements:
       build:
         - {{ compiler('c') }}
@@ -185,7 +203,10 @@ outputs:
         - nomkl
         - {{ pin_subpackage('libmagma', exact=True) }}
       run:
+        - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
         - {{ pin_subpackage('libmagma', exact=True) }}
+        - cuda-cudart
+        - libcusparse
     test:
       commands:
         - test -f $PREFIX/lib/libmagma_sparse${SHLIB_EXT}        # [unix]
@@ -211,6 +232,8 @@ outputs:
       run_exports:
         - {{ pin_subpackage('libmagma', max_pin='x.x.x') }}
         - {{ pin_subpackage('libmagma_sparse', max_pin='x.x.x') }}
+      ignore_run_exports:
+        - cuda-version
     requirements:
       build:
         - {{ compiler('c') }}
@@ -224,6 +247,7 @@ outputs:
         - {{ pin_subpackage('libmagma', exact=True) }}
         - {{ pin_subpackage('libmagma_sparse', exact=True) }}
       run:
+        - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
         - {{ pin_subpackage('libmagma', exact=True) }}  # [not win]
         - {{ pin_subpackage('libmagma_sparse', exact=True) }}  # [not win]
     test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Closes #32 

Adjusts `cuda-version` pinnings so that libmagma has minor version compatibility. i.e. it is installable with an same major `cuda-version`. This is probably true since there is only one minor source code macro which switches at `CUDA_VERSION >= 12.6`, and this change does not switch APIs, it just fixes a header collision.

I've tested compatibility by compiling with CTK 12.9, then running upstream's single-GPU integration tests on a Maxwell generation GPU with the CUDA 12.0 toolkit. The tests were passing for single precision.